### PR TITLE
Added titles for each page in Sluggo, can be edited as needed

### DIFF
--- a/templates/auth.html
+++ b/templates/auth.html
@@ -1,13 +1,13 @@
 <!--
-  auth.html - template file for auth page, derived from py4web 
+  auth.html - template file for auth page, derived from py4web
   part of Sluggo, a free and open source issue tracker
   Copyright (c) 2020 Slugbotics - see git repository history for individual committers
-  
+
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -->
-
+[[block page_head]]<title>Sluggo/Sign-in</title>[[end]]
 [[extend "layout.html"]]
 
 <div class="container title has-text-centered">

--- a/templates/create_profile.html
+++ b/templates/create_profile.html
@@ -2,12 +2,12 @@
   create_profile.html - template file for profile creation page
   part of Sluggo, a free and open source issue tracker
   Copyright (c) 2020 Slugbotics - see git repository history for individual committers
-  
+
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -->
-
+[[block page_head]]<title>Sluggo/Create User</title>[[end]]
 [[extend 'layout.html']]
 <div id="vue-target">
     <section class="section">

--- a/templates/help.html
+++ b/templates/help.html
@@ -2,12 +2,12 @@
   help.html - template file for help page
   part of Sluggo, a free and open source issue tracker
   Copyright (c) 2020 Slugbotics - see git repository history for individual committers
-  
+
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -->
-
+[[block page_head]]<title>Sluggo/Help</title>[[end]]
 [[extend 'layout.html']]
 <div id="help-target">
     <section class="section">

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,16 +2,16 @@
   index.html - template file for homepage
   part of Sluggo, a free and open source issue tracker
   Copyright (c) 2020 Slugbotics - see git repository history for individual committers
-  
+
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -->
-
 [[extend "layout.html"]]
 
 [[block page_head]]
 <link rel="stylesheet" href="[[=URL('static', 'css/pages/index.css')]]">
+<title>Sluggo</title>
 [[end]]
 
 <div v-cloak id="hp-target" class="section">
@@ -81,7 +81,7 @@
                          <!-- generic debug -->
                          <!-- <p>User {{e.web_action_user_name}} performed action {{e.type}} with content {{e.description}}
                             on ticket {{e.related_ticket}}
-                         </p> --> 
+                         </p> -->
                          <p v-if="e.type === 'post-comment'">{{e.web_action_user_name}} posted on Ticket
                             {{e.related_ticket}}: "{{e.description}}"
                          </p>
@@ -116,11 +116,11 @@
                      <p>You don't have any starred tickets.</p>
                   </div>
                </div>
-               <div class="sluggo_pinned_ticket notification" v-for="pt in pinned_tickets" 
+               <div class="sluggo_pinned_ticket notification" v-for="pt in pinned_tickets"
                v-bind:class="{'is-info': !checkOverdue(pt) && !checkStarted(pt) && !checkCompleted(pt), 'is-warning': !checkOverdue(pt) && checkStarted(pt) && !checkCompleted(pt), 'is-danger': checkOverdue(pt) && !checkCompleted(pt), 'is-success': checkCompleted(pt)}">
                   <div class="columns is-mobile">
                      <div class="column is-10" @click="goToTicket(pt.id)">
-                        <p class="is-size-5">Ticket {{pt.id}} | {{pt.tag_string}} | {{pt.ticket_title}} 
+                        <p class="is-size-5">Ticket {{pt.id}} | {{pt.tag_string}} | {{pt.ticket_title}}
                         </p>
                         <p v-if="typeof(pt.web_due) !== 'undefined'">Due {{formatBadDate(pt.web_due)}}</p>
                         <!-- <p>Due May 25, 2020.</p> -->

--- a/templates/specific_user.html
+++ b/templates/specific_user.html
@@ -2,12 +2,12 @@
   specific_user.html - template file for user profile page
   part of Sluggo, a free and open source issue tracker
   Copyright (c) 2020 Slugbotics - see git repository history for individual committers
-  
+
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -->
-
+[[block page_head]]<title>Sluggo/User/[[=XML(id)]]</title>[[end]]
 [[extend 'layout.html']]
 <div class="section" id="vue-user">
   <div class="container">

--- a/templates/ticket_details.html
+++ b/templates/ticket_details.html
@@ -2,16 +2,15 @@
   ticket_details.html - template file for ticket details page
   part of Sluggo, a free and open source issue tracker
   Copyright (c) 2020 Slugbotics - see git repository history for individual committers
-  
+
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -->
-
 [[extend 'layout.html']]
 
 [[block page_head]]
-
+<title>Sluggo/Ticket Details</title>
 <link rel="stylesheet" href="[[=URL('static/components/add_subticket_modal/add_subticket_modal.css')]]">
 <link rel="stylesheet" href="[[=URL('static/components/ticket_modal/ticket_modal.css')]]">
 [[end]]

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -2,15 +2,15 @@
   tickets.html - template file for tickets page
   part of Sluggo, a free and open source issue tracker
   Copyright (c) 2020 Slugbotics - see git repository history for individual committers
-  
+
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -->
-
 [[extend 'layout.html']]
 
 [[block page_head]]
+<title>Sluggo/Tickets</title>
 <link rel="stylesheet" href="[[=URL('static/components/ticket_modal/ticket_modal.css')]]">
 [[end]]
 

--- a/templates/users.html
+++ b/templates/users.html
@@ -2,12 +2,12 @@
   users.html - template file for users page
   part of Sluggo, a free and open source issue tracker
   Copyright (c) 2020 Slugbotics - see git repository history for individual committers
-  
+
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -->
-
+[[block page_head]]<title>Sluggo/Users</title>[[end]]
 [[extend 'layout.html']]
 <div class="section" id="vue-users">
    <div class="container">


### PR DESCRIPTION
Each page now has a proper title attribute that can be adjusted as needed in the <title> tag. Currently it's format is Sluggo/page_name but that can be adjusted if people think of better versions.