### PR TITLE
Added py4web to requirements (repo fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ A modern, simple issue tracker for teams. Currently in the prototype stage. App 
 Begin by installing py4web, the server which powers Sluggo. py4web and relating installation instructions can be found
 here: https://github.com/web2py/py4web
 
-In addition to py4web, Sluggo relies on libraries specified in our requirements.txt file:
-
-`pip install -r requirements.txt`
+In addition to py4web, Sluggo relies on a few additional libraries. Install the following packages:
+```pip install python-dateutil```
 
 You should then have all necessary prerequisites to run Sluggo.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 python-dateutil
+py4web


### PR DESCRIPTION
This adds py4web to requirements.txt, and updates the README instructions accordingly.

### Justification
* Sluggo will show up as a dependent on py4web's repo, increasing visibility
* py4web shows up as a dependency on GitHub, making it easier for people to understand dependency.

### Further Changes Required
* pip commands no longer simply installable directly from requirements.txt. **Mitigation: just install python-dateutil, same amount of commands for now.**
(There might be a cleaner way to mitigate this)