### PR TITLE
Agavgavi/comment fix

### DIFF
--- a/components/comment.py
+++ b/components/comment.py
@@ -81,7 +81,8 @@ class Comment(Fixture):
 
         for comment in comments:
             comment['editable'] = comment.get('user_id') == self.auth.current_user.get('id') or user.role == "admin"
-            comment['img_url'] = Helper.get_user_icon(user["icon"])
+            comment_creator = self.db(self.db.users.user == comment.get('user_id')).select().first()
+            comment['img_url'] = Helper.get_user_icon(comment_creator["icon"])
 
         return dict(comments=comments)
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -2,7 +2,7 @@
   admin.html - template file for admin page
   part of Sluggo, a free and open source issue tracker
   Copyright (c) 2020 Slugbotics - see git repository history for individual committers
-  
+
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -217,6 +217,7 @@
             <thead>
               <tr>
                 <th>Name</th>
+                <th>Email</th>
                 <th>Tags</th>
                 <th>Bio</th>
                 <th>Approve?</th>
@@ -228,6 +229,7 @@
               </tr>
               <tr v-else v-for="user in users">
                 <th>{{user.full_name}}</th>
+                <td>{{user.user_email}}</td>
                 <td>{{user.tags_list}}</td>
                 <td>{{user.bio}}</td>
                 <td>
@@ -248,6 +250,7 @@
             <thead>
               <tr>
                 <th>Name</th>
+                <th>Email</th>
                 <th>Role</th>
                 <th>Tags</th>
                 <th>Bio</th>
@@ -257,6 +260,7 @@
             <tbody>
               <tr v-for="user in all_users">
                 <th>{{user.full_name}}</th>
+                <td>{{user.user_email}}</td>
                 <th :class="getColor(user._idx)">{{user.role}}</th>
                 <td>{{user.tags_list}}</td>
                 <td>{{user.bio}}</td>


### PR DESCRIPTION
Fixed the error of comments showing the wrong profile picture as seen on #19 on the tracker. Also added an email field to the admin members page to allow for an easier way of knowing who people are.